### PR TITLE
Swings and flings are no longer mixed up

### DIFF
--- a/src/main/java/net/splatcraft/forge/client/audio/ChargerChargingTickableSound.java
+++ b/src/main/java/net/splatcraft/forge/client/audio/ChargerChargingTickableSound.java
@@ -46,7 +46,6 @@ public class ChargerChargingTickableSound extends TickableSound
             {
                 if (PlayerCharge.getChargeValue(player, player.getUseItem()) >= 1 && !isStopped())
                 {
-                    player.level.playSound(player, player.getX(), player.getY(), player.getZ(), SplatcraftSounds.chargerReady, SoundCategory.PLAYERS, 1, 1);
                     stop();
                     return;
                 }

--- a/src/main/java/net/splatcraft/forge/client/audio/ChargerChargingTickableSound.java
+++ b/src/main/java/net/splatcraft/forge/client/audio/ChargerChargingTickableSound.java
@@ -1,16 +1,16 @@
 package net.splatcraft.forge.client.audio;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.TickableSound;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.MathHelper;
 import net.splatcraft.forge.data.capabilities.playerinfo.IPlayerInfo;
 import net.splatcraft.forge.data.capabilities.playerinfo.PlayerInfoCapability;
 import net.splatcraft.forge.items.weapons.ChargerItem;
 import net.splatcraft.forge.items.weapons.WeaponBaseItem;
 import net.splatcraft.forge.registries.SplatcraftSounds;
 import net.splatcraft.forge.util.PlayerCharge;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.audio.TickableSound;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.util.SoundCategory;
-import net.minecraft.util.math.MathHelper;
 
 public class ChargerChargingTickableSound extends TickableSound
 {
@@ -45,7 +45,7 @@ public class ChargerChargingTickableSound extends TickableSound
             IPlayerInfo info = PlayerInfoCapability.get(player);
             if (!info.isSquid())
             {
-                volume = WeaponBaseItem.hasInk(player, player.getUseItem()) ? 1 : 0;
+                volume = WeaponBaseItem.enoughInk(player, 0.01f, false) ? 1 : 0;
 
                 if (PlayerCharge.getChargeValue(player, player.getUseItem()) >= 1 && !isStopped())
                 {

--- a/src/main/java/net/splatcraft/forge/client/audio/ChargerChargingTickableSound.java
+++ b/src/main/java/net/splatcraft/forge/client/audio/ChargerChargingTickableSound.java
@@ -8,7 +8,6 @@ import net.minecraft.util.math.MathHelper;
 import net.splatcraft.forge.data.capabilities.playerinfo.IPlayerInfo;
 import net.splatcraft.forge.data.capabilities.playerinfo.PlayerInfoCapability;
 import net.splatcraft.forge.items.weapons.ChargerItem;
-import net.splatcraft.forge.items.weapons.WeaponBaseItem;
 import net.splatcraft.forge.registries.SplatcraftSounds;
 import net.splatcraft.forge.util.PlayerCharge;
 
@@ -45,8 +44,6 @@ public class ChargerChargingTickableSound extends TickableSound
             IPlayerInfo info = PlayerInfoCapability.get(player);
             if (!info.isSquid())
             {
-                volume = WeaponBaseItem.enoughInk(player, 0.01f, false) ? 1 : 0;
-
                 if (PlayerCharge.getChargeValue(player, player.getUseItem()) >= 1 && !isStopped())
                 {
                     player.level.playSound(player, player.getX(), player.getY(), player.getZ(), SplatcraftSounds.chargerReady, SoundCategory.PLAYERS, 1, 1);

--- a/src/main/java/net/splatcraft/forge/client/audio/RollerRollTickableSound.java
+++ b/src/main/java/net/splatcraft/forge/client/audio/RollerRollTickableSound.java
@@ -1,9 +1,5 @@
 package net.splatcraft.forge.client.audio;
 
-import net.splatcraft.forge.handlers.WeaponHandler;
-import net.splatcraft.forge.items.weapons.RollerItem;
-import net.splatcraft.forge.items.weapons.WeaponBaseItem;
-import net.splatcraft.forge.registries.SplatcraftSounds;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.TickableSound;
 import net.minecraft.entity.Entity;
@@ -12,6 +8,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector3d;
+import net.splatcraft.forge.handlers.WeaponHandler;
+import net.splatcraft.forge.items.weapons.RollerItem;
+import net.splatcraft.forge.items.weapons.WeaponBaseItem;
+import net.splatcraft.forge.registries.SplatcraftSounds;
 
 public class RollerRollTickableSound extends TickableSound
 {
@@ -43,8 +43,7 @@ public class RollerRollTickableSound extends TickableSound
         if (this.player.isAlive() && player.getUseItem().getItem() instanceof RollerItem)
         {
             ItemStack roller = player.getUseItem();
-            if (WeaponBaseItem.getInkAmount(player, roller) < Math.max(((RollerItem) roller.getItem()).rollConsumptionMin, ((RollerItem) roller.getItem()).rollConsumptionMax))
-            {
+            if (!WeaponBaseItem.enoughInk(player, Math.max(((RollerItem) roller.getItem()).rollConsumptionMin, ((RollerItem) roller.getItem()).rollConsumptionMax), false)) {
                 stop();
                 return;
             }

--- a/src/main/java/net/splatcraft/forge/items/InkTankItem.java
+++ b/src/main/java/net/splatcraft/forge/items/InkTankItem.java
@@ -25,6 +25,7 @@ import net.splatcraft.forge.registries.SplatcraftItemGroups;
 import net.splatcraft.forge.registries.SplatcraftItems;
 import net.splatcraft.forge.util.ColorUtils;
 import net.splatcraft.forge.util.InkBlockUtils;
+import net.splatcraft.forge.util.PlayerCooldown;
 import net.splatcraft.forge.util.SplatcraftArmorMaterial;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -70,19 +71,15 @@ public class InkTankItem extends ColoredArmorItem
     }
 
 
-    public static float getInkAmount(ItemStack stack)
-    {
-        return stack.getOrCreateTag().getFloat("Ink");
-    }
-
-    public static float getInkAmount(ItemStack tank, ItemStack weapon)
-    {
-        return ((InkTankItem) tank.getItem()).canUse(weapon.getItem()) ? getInkAmount(tank) : 0;
+    public static float getInkAmount(ItemStack stack) {
+        float capacity = ((InkTankItem) stack.getItem()).capacity;
+        if (stack.getOrCreateTag().getBoolean("InfiniteInk")) return capacity;
+        return Math.max(0, Math.min(capacity, stack.getOrCreateTag().getFloat("Ink")));
     }
 
     public static void setInkAmount(ItemStack stack, float value)
     {
-        stack.getOrCreateTag().putFloat("Ink", value);
+        stack.getOrCreateTag().putFloat("Ink", Math.max(0, Math.min(((InkTankItem) stack.getItem()).capacity, value)));
     }
 
     public static boolean canRecharge(ItemStack stack)
@@ -101,9 +98,8 @@ public class InkTankItem extends ColoredArmorItem
             float ink = getInkAmount(stack);
 
             if (canRecharge(stack) && player.getItemBySlot(EquipmentSlotType.CHEST).equals(stack) && ColorUtils.colorEquals(player, stack) && ink < capacity
-                    && (!(player.getUseItem().getItem() instanceof WeaponBaseItem) || player.getUseItem().getItem() instanceof IChargeableWeapon))
-            {
-                setInkAmount(stack, Math.min(capacity, ink + (InkBlockUtils.canSquidHide(player) && PlayerInfoCapability.isSquid(player) ? 1.1125f : .11125f)));
+                    && (!(player.getUseItem().getItem() instanceof WeaponBaseItem) || player.getUseItem().getItem() instanceof IChargeableWeapon || PlayerCooldown.hasPlayerCooldown(player))) {
+                setInkAmount(stack, ink + (InkBlockUtils.canSquidHide(player) && PlayerInfoCapability.isSquid(player) ? 1.1125f : .11125f));
             }
         }
     }

--- a/src/main/java/net/splatcraft/forge/items/weapons/ChargerItem.java
+++ b/src/main/java/net/splatcraft/forge/items/weapons/ChargerItem.java
@@ -5,8 +5,6 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
@@ -93,7 +91,7 @@ public class ChargerItem extends WeaponBaseItem implements IChargeableWeapon
     @Override
     public void onRelease(World level, PlayerEntity player, ItemStack stack, float charge)
     {
-        InkProjectileEntity proj = new InkProjectileEntity(level, player, stack, InkBlockUtils.getInkType(player), projectileSize, charge > 0.95f ? damage : damage * charge / 4f + damage / 4f);
+        InkProjectileEntity proj = new InkProjectileEntity(level, player, stack, InkBlockUtils.getInkType(player), projectileSize, charge > 0.95f ? damage : damage * charge / 5f + damage / 5f);
         proj.setChargerStats((int) (projectileLifespan * charge), charge >= pierceCharge);
         proj.shootFromRotation(player, player.xRot, player.yRot, 0.0f, projectileSpeed, 0.1f);
         level.addFreshEntity(proj);
@@ -107,18 +105,8 @@ public class ChargerItem extends WeaponBaseItem implements IChargeableWeapon
     public void weaponUseTick(World level, LivingEntity entity, ItemStack stack, int timeLeft) {
         if (entity instanceof PlayerEntity && enoughInk(entity, getInkConsumption(PlayerCharge.getChargeValue((PlayerEntity) entity, stack)), timeLeft % 4 == 0) && level.isClientSide && !((PlayerEntity) entity).getCooldowns().isOnCooldown(this)) {
             PlayerCharge.addChargeValue((PlayerEntity) entity, stack, chargeSpeed * (!entity.isOnGround() && !airCharge ? 0.5f : 1));
+            playChargingSound((PlayerEntity) entity);
         }
-    }
-
-    @Override
-    public @NotNull ActionResult<ItemStack> use(@NotNull World level, PlayerEntity player, @NotNull Hand hand)
-    {
-        ActionResult<ItemStack> result = super.use(level, player, hand);
-
-        if (level.isClientSide && !(player.isSwimming() && !player.isInWater()))
-            playChargingSound(player);
-
-        return result;
     }
 
     @Override

--- a/src/main/java/net/splatcraft/forge/items/weapons/ChargerItem.java
+++ b/src/main/java/net/splatcraft/forge/items/weapons/ChargerItem.java
@@ -98,14 +98,23 @@ public class ChargerItem extends WeaponBaseItem implements IChargeableWeapon
         level.playSound(null, player.getX(), player.getY(), player.getZ(), SplatcraftSounds.chargerShot, SoundCategory.PLAYERS, 0.7F, ((level.getRandom().nextFloat() - level.getRandom().nextFloat()) * 0.1F + 1.0F) * 0.95F);
         reduceInk(player, getInkConsumption(charge), false);
         PlayerCooldown.setPlayerCooldown(player, new PlayerCooldown(stack, 10, player.inventory.selected, player.getUsedItemHand(), true, false, false, player.isOnGround()));
-        player.getCooldowns().addCooldown(this, 10);
+        player.getCooldowns().addCooldown(this, 7);
     }
 
     @Override
     public void weaponUseTick(World level, LivingEntity entity, ItemStack stack, int timeLeft) {
-        if (entity instanceof PlayerEntity && enoughInk(entity, getInkConsumption(PlayerCharge.getChargeValue((PlayerEntity) entity, stack)), timeLeft % 4 == 0) && level.isClientSide && !((PlayerEntity) entity).getCooldowns().isOnCooldown(this)) {
-            PlayerCharge.addChargeValue((PlayerEntity) entity, stack, chargeSpeed * (!entity.isOnGround() && !airCharge ? 0.5f : 1));
-            playChargingSound((PlayerEntity) entity);
+        if (entity instanceof PlayerEntity) {
+            PlayerEntity player = (PlayerEntity) entity;
+            float prevCharge = PlayerCharge.getChargeValue(player, stack);
+            float newCharge = prevCharge + (chargeSpeed * (!entity.isOnGround() && !airCharge ? 0.33f : 1));
+            if (enoughInk(entity, getInkConsumption(newCharge), timeLeft % 4 == 0) && level.isClientSide && !player.getCooldowns().isOnCooldown(this))
+            {
+                if (prevCharge < 1 && newCharge >= 1) {
+                    player.level.playSound(player, player.getX(), player.getY(), player.getZ(), SplatcraftSounds.chargerReady, SoundCategory.PLAYERS, 1, 1);
+                } else if (newCharge < 1)
+                    playChargingSound(player);
+                PlayerCharge.addChargeValue(player, stack, newCharge - prevCharge);
+            }
         }
     }
 

--- a/src/main/java/net/splatcraft/forge/items/weapons/WeaponBaseItem.java
+++ b/src/main/java/net/splatcraft/forge/items/weapons/WeaponBaseItem.java
@@ -62,43 +62,10 @@ public class WeaponBaseItem extends Item implements IColoredItem
         SplatcraftItems.weapons.add(this);
     }
 
-    @Deprecated
-    public static float getInkAmount(LivingEntity player, ItemStack weapon)
-    {
-        if (!SplatcraftGameRules.getBooleanRuleValue(player.level, SplatcraftGameRules.REQUIRE_INK_TANK))
-        {
-            return Float.MAX_VALUE;
-        }
-
-        ItemStack tank = player.getItemBySlot(EquipmentSlotType.CHEST);
-        if (!(tank.getItem() instanceof InkTankItem))
-        {
-            return 0;
-        }
-
-        return InkTankItem.getInkAmount(tank, weapon);
-    }
-
-    public static boolean hasInk(LivingEntity player, ItemStack weapon)
-    {
-        return getInkAmount(player, weapon) > 0;
-    }
-
     public static boolean reduceInk(LivingEntity player, float amount, boolean sendMessage)
     {
+        if (!enoughInk(player, amount, sendMessage, false)) return false;
         ItemStack tank = player.getItemBySlot(EquipmentSlotType.CHEST);
-        if (!SplatcraftGameRules.getBooleanRuleValue(player.level, SplatcraftGameRules.REQUIRE_INK_TANK)
-                || player instanceof PlayerEntity && ((PlayerEntity)player).isCreative())
-        {
-            return true;
-        }
-        if (!(tank.getItem() instanceof InkTankItem) || InkTankItem.getInkAmount(tank) - amount < 0)
-        {
-            if (sendMessage)
-                sendNoInkMessage(player);
-            return false;
-        }
-
         InkTankItem.setInkAmount(tank, InkTankItem.getInkAmount(tank) - amount);
         return true;
     }
@@ -110,22 +77,16 @@ public class WeaponBaseItem extends Item implements IColoredItem
     public static boolean enoughInk(LivingEntity player, float consumption, boolean sendMessage, boolean sub) {
         ItemStack tank = player.getItemBySlot(EquipmentSlotType.CHEST);
         if (!SplatcraftGameRules.getBooleanRuleValue(player.level, SplatcraftGameRules.REQUIRE_INK_TANK)
-                || player instanceof PlayerEntity && ((PlayerEntity)player).isCreative())
-        {
+                || player instanceof PlayerEntity && ((PlayerEntity) player).isCreative()
+                && SplatcraftGameRules.getBooleanRuleValue(player.level, SplatcraftGameRules.INFINITE_INK_IN_CREATIVE)) {
             return true;
         }
-        if (!(tank.getItem() instanceof InkTankItem) || InkTankItem.getInkAmount(tank) - consumption < 0)
-        {
+        if (!(tank.getItem() instanceof InkTankItem) || InkTankItem.getInkAmount(tank) - consumption < 0) {
             if (sendMessage)
                 sendNoInkMessage(player, sub ? SplatcraftSounds.noInkSub : SplatcraftSounds.noInkMain);
             return false;
         }
         return true;
-    }
-
-    public static void sendNoInkMessage(LivingEntity entity)
-    {
-        sendNoInkMessage(entity, SplatcraftSounds.noInkMain);
     }
 
     public static void sendNoInkMessage(LivingEntity entity, SoundEvent sound)

--- a/src/main/java/net/splatcraft/forge/items/weapons/WeaponBaseItem.java
+++ b/src/main/java/net/splatcraft/forge/items/weapons/WeaponBaseItem.java
@@ -66,7 +66,8 @@ public class WeaponBaseItem extends Item implements IColoredItem
     {
         if (!enoughInk(player, amount, sendMessage, false)) return false;
         ItemStack tank = player.getItemBySlot(EquipmentSlotType.CHEST);
-        InkTankItem.setInkAmount(tank, InkTankItem.getInkAmount(tank) - amount);
+        if (tank.getItem() instanceof InkTankItem)
+            InkTankItem.setInkAmount(tank, InkTankItem.getInkAmount(tank) - amount);
         return true;
     }
 

--- a/src/main/java/net/splatcraft/forge/registries/SplatcraftGameRules.java
+++ b/src/main/java/net/splatcraft/forge/registries/SplatcraftGameRules.java
@@ -1,10 +1,10 @@
 package net.splatcraft.forge.registries;
 
-import net.splatcraft.forge.Splatcraft;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.GameRules.Category;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.splatcraft.forge.Splatcraft;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -28,6 +28,7 @@ public class SplatcraftGameRules
     public static GameRules.RuleKey<GameRules.BooleanValue> INK_FRIENDLY_FIRE;
     public static GameRules.RuleKey<GameRules.BooleanValue> INK_REGEN;
     public static GameRules.RuleKey<GameRules.BooleanValue> INK_DAMAGE_COOLDOWN;
+    public static GameRules.RuleKey<GameRules.BooleanValue> INFINITE_INK_IN_CREATIVE;
 
     public static void registerGamerules()
     {
@@ -42,6 +43,7 @@ public class SplatcraftGameRules
         INK_REGEN = createBooleanRule("inkHealing", Category.PLAYER, true);
         INK_DAMAGE_COOLDOWN = createBooleanRule("inkDamageCooldown", Category.PLAYER, false);
         INK_MOB_DAMAGE_PERCENTAGE = createIntRule("inkMobDamagePercentage", Category.MOBS, 0);
+        INFINITE_INK_IN_CREATIVE = createBooleanRule("infiniteInkInCreative", Category.PLAYER, true);
     }
 
     public static GameRules.RuleKey<GameRules.BooleanValue> createBooleanRule(String name, GameRules.Category category, boolean defaultValue)

--- a/src/main/java/net/splatcraft/forge/util/ClientUtils.java
+++ b/src/main/java/net/splatcraft/forge/util/ClientUtils.java
@@ -1,9 +1,5 @@
 package net.splatcraft.forge.util;
 
-import net.splatcraft.forge.SplatcraftConfig;
-import net.splatcraft.forge.items.InkTankItem;
-import net.splatcraft.forge.items.weapons.WeaponBaseItem;
-import net.splatcraft.forge.registries.SplatcraftGameRules;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -11,12 +7,12 @@ import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
 import net.minecraft.util.MovementInput;
-import net.minecraft.util.SoundCategory;
-import net.minecraft.util.SoundEvent;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.splatcraft.forge.SplatcraftConfig;
+import net.splatcraft.forge.items.InkTankItem;
+import net.splatcraft.forge.registries.SplatcraftGameRules;
 
 import java.util.TreeMap;
 
@@ -72,14 +68,9 @@ public class ClientUtils
         ItemStack chestpiece = player.getItemBySlot(EquipmentSlotType.CHEST);
         if (chestpiece.getItem() instanceof InkTankItem)
         {
-            return 1 - WeaponBaseItem.getInkAmount(player, stack) / ((InkTankItem) chestpiece.getItem()).capacity;
+            return 1 - InkTankItem.getInkAmount(chestpiece) / ((InkTankItem) chestpiece.getItem()).capacity;
         }
         return 1;
-    }
-
-    public static void playClientSound(BlockPos pos, SoundEvent soundIn, SoundCategory category, float volume, float pitch)
-    {
-        Minecraft.getInstance().getSoundManager().play(new ClientPlayerSound(soundIn, category, volume, pitch));
     }
 
     public static boolean canPerformRoll(PlayerEntity entity)

--- a/src/main/resources/assets/splatcraft/lang/en_us.json
+++ b/src/main/resources/assets/splatcraft/lang/en_us.json
@@ -376,7 +376,8 @@
   "gamerule.splatcraft.inkDamageCooldown.description": "Prevents ink damage from bypassing hurt resistance time.",
   "gamerule.splatcraft.inkMobDamagePercentage": "Ink Mob Damage Percentage",
   "gamerule.splatcraft.inkMobDamagePercentage.description": "Determines how much damage is dealt by regular Splatcraft weapons against mobs.",
-
+  "gamerule.splatcraft.infiniteInkInCreative": "Infinite Ink in Creative Mode",
+  "gamerule.splatcraft.infiniteInkInCreative.description": "Players in Creative Mode will not need an ink tank or refill ink to use Splatcraft weapons",
   "status.coord_set.a": "Set first position to X: %s Y: %s Z: %s",
   "status.coord_set.b": "Set second position to X: %s Y: %s Z: %s",
   "status.no_ink": "Low Ink!",


### PR DESCRIPTION
help I need better PR titles

- Fixed chargers playing charging sound when you don't have an ink tank
- Put upper and lower bounds on ink tank amount
- Added `InfiniteInk` tag for ink tanks
- Ink recovery is now blocked for non-rapid fire weapons
- Decreased charger damage when charge is below 95%
- Decreased charger cooldown from 0.5s to 0.35s
- Removed unused getters in RollerItem
- Fixed mixups between swings (on-ground attacks) and flings (mid-air attacks)
- Removed redundant code in WeaponBaseItem ink-related checks
- Added a new game rule for having infinite ink while in Creative Mode